### PR TITLE
Set compile flags from engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,12 +115,24 @@ add_library(OpenNN SHARED
 		${OPENNN_SRC}
 )
 
+# We assume that these variables were set before gipOpenNN plugin was included,
+# it will be a problem if that order is ever changed.
+
+# If these are not set, it will compile with default flags which might be slower because it lacks proper optimization flags.
+list(APPEND GLIST_CXX_FLAGS_DEBUG ${GLIST_CXX_FLAGS_COMMON} ${GLIST_CXX_FLAGS_DEBUG})
+list(APPEND GLIST_CXX_FLAGS_RELEASE ${GLIST_CXX_FLAGS_COMMON} ${GLIST_CXX_FLAGS_RELEASE})
+target_compile_options(
+		OpenNN
+		PRIVATE
+		$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:${GLIST_CXX_FLAGS_DEBUG}>
+		$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:${GLIST_CXX_FLAGS_RELEASE}>
+)
+
 if(DEFINED WIN32)
 	target_link_libraries(OpenNN PUBLIC
 			omp
 	)
 endif()
-
 
 # Link headers to the library
 target_include_directories(OpenNN PUBLIC


### PR DESCRIPTION
This PR fixes gipOpenNN being slower than before. The issue was caused by missing compile flags which this PR adds.